### PR TITLE
Simple fix for logical indexing bug

### DIFF
--- a/src/Axes/indexing.jl
+++ b/src/Axes/indexing.jl
@@ -8,7 +8,9 @@ end
 
 @inline function unsafe_getindex(A, args::Tuple, inds::Tuple)
     p = @inbounds(getindex(parent(A), inds...))
-    if (p isa AbstractVector) && is_dynamic(p)
+    if any(typeof.(inds) .<: AbstractArray{<:Bool})
+        return p
+    elseif (p isa AbstractVector) && is_dynamic(p)
         return unsafe_reconstruct(A, p, to_axes(A, args, inds, (as_dynamic(axes(p, 1)),), false))
     else
         return unsafe_reconstruct(A, p, to_axes(A, args, inds, axes(p), false))
@@ -21,6 +23,9 @@ end
 
 function unsafe_view(A, args::Tuple, inds::Tuple)
     p = view(parent(A), inds...)
+    if any(typeof.(inds) .<: AbstractArray{<:Bool})
+        return p
+    end
     return unsafe_reconstruct(A, p, to_axes(A, args, inds, axes(p), false))
 end
 
@@ -30,6 +35,9 @@ end
 
 function unsafe_dotview(A, args::Tuple, inds::Tuple)
     p = Base.dotview(parent(A), inds...)
+    if any(typeof.(inds) .<: AbstractArray{<:Bool})
+        return p
+    end
     return unsafe_reconstruct(A, p, to_axes(A, args, inds, axes(p), false))
 end
 

--- a/src/NamedAxes/NamedAxisArray.jl
+++ b/src/NamedAxes/NamedAxisArray.jl
@@ -124,6 +124,10 @@ for f in (:getindex, :view, :dotview)
                 return NamedDimsArray{L}(data)
             end
         end
+
+        @propagate_inbounds function Base.$f(a::NamedAxisArray, mapping::Union{NamedTuple,AbstractDict})
+            Base.$f(a; mapping...)
+        end
     end
 end
 

--- a/src/NamedAxes/NamedAxisArray.jl
+++ b/src/NamedAxes/NamedAxisArray.jl
@@ -116,7 +116,7 @@ for f in (:getindex, :view, :dotview)
             data = @inbounds(Base.$f(parent(a), inds...))
             data isa AbstractArray || return data # Case of scalar output
             L = NamedDims.remaining_dimnames_from_indexing(dimnames(a), inds)
-            if L === ()
+            if L === () || any(typeof.(inds) .<: AbstractArray{<:Bool})
                 # Cases that merge dimensions down to vector like `mat[mat .> 0]`,
                 # and also zero-dimensional `view(mat, 1,1)`
                 return data


### PR DESCRIPTION
fixes #36 

I don't think this is the best way to fix this, but I can't find `NamedDims.remaining_dimnames_from_indexing` nor do I see an analogous fix for plain AxisArrays (I suspect some kind of dispatch would work best there, using `Union{Integer,<:AbstractArray{Bool}}` instead of just `Integer`).

Happy to update as you see fit, or of course you're welcome to edit.

edit: it very clearly says `NamedDims.` so obviously it's in the `NamedDims` package.... I'll go look over there, then.