### PR TITLE
Typo in docs url: Tokazma -> Tokazama

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -31,7 +31,7 @@ makedocs(;
         "Comparison to Other Packages" => "comparison.md",
         "Acknowledgments" => "acknowledgments.md"
     ],
-    repo="https://github.com/Tokazma/AxisIndices.jl/blob/{commit}{path}#L{line}",
+    repo="https://github.com/Tokazama/AxisIndices.jl/blob/{commit}{path}#L{line}",
     sitename="AxisIndices.jl",
     authors="Zachary P. Christensen",
 )


### PR DESCRIPTION
The `Edit on GitHub` and `Source` links in the docs lead to a 404. I think this edit should fix that.