### PR TITLE
Kwargs data and unsafe_length

### DIFF
--- a/src/axis_array.jl
+++ b/src/axis_array.jl
@@ -417,7 +417,7 @@ end
 function ArrayInterface.unsafe_get_collection(A::AxisArray, inds)
     axs = to_axes(A, inds)
     dest = AxisArray(similar(parent(A), length.(axs)), axs)
-    if map(Base.unsafe_length, axes(dest)) == map(Base.unsafe_length, axs)
+    if map(length, axes(dest)) == map(length, axs)
         Base._unsafe_getindex!(dest, A, inds...) # usually a generated function, don't allow it to impact inference result
     else
         Base.throw_checksize_error(dest, axs)

--- a/src/named.jl
+++ b/src/named.jl
@@ -192,7 +192,7 @@ function NamedAxisArray{L,T}(init::ArrayInitializer, args::AbstractVector...) wh
     return NamedAxisArray{L,T}(init, args)
 end
 
-NamedAxisArray(x::AbstractArray; kwargs...) = NamedAxisArray(x, kwargs.data)
+NamedAxisArray(x::AbstractArray; kwargs...) = NamedAxisArray(x, values(kwargs))
 
 for f in (:getindex, :view, :dotview)
     @eval begin


### PR DESCRIPTION
Fixes a couple of things that have deprecation warnings on nightly.

`kwargs.data` -> `values(kwargs)` (see https://github.com/JuliaLang/julia/pull/39448)

and

`Base.unsafe_length` -> `length` (see https://github.com/JuliaLang/julia/pull/40382)